### PR TITLE
Add Send & Sync trait to Aggregator

### DIFF
--- a/src/agg/mod.rs
+++ b/src/agg/mod.rs
@@ -9,7 +9,7 @@ use crate::taxon;
 use crate::taxon::TaxonId;
 
 /// Allows to aggregate over a taxon tree.
-pub trait Aggregator: Send + Sync {
+pub trait Aggregator {
     /// Aggregates a set of scored taxons into a resulting taxon id.
     fn aggregate(&self, taxons: &HashMap<TaxonId, f32>) -> Result<TaxonId>;
 
@@ -19,6 +19,9 @@ pub trait Aggregator: Send + Sync {
         self.aggregate(&count(taxons))
     }
 }
+
+/// Allows reusing a single aggregator across multiple threads
+pub trait MultiThreadSafeAggregator: Aggregator + Sync + Send {}
 
 /// Returns how many times each taxon occurs in a vector of taxons.
 pub fn count<T>(taxons: T) -> HashMap<TaxonId, f32>

--- a/src/agg/mod.rs
+++ b/src/agg/mod.rs
@@ -9,7 +9,7 @@ use crate::taxon;
 use crate::taxon::TaxonId;
 
 /// Allows to aggregate over a taxon tree.
-pub trait Aggregator {
+pub trait Aggregator: Send + Sync {
     /// Aggregates a set of scored taxons into a resulting taxon id.
     fn aggregate(&self, taxons: &HashMap<TaxonId, f32>) -> Result<TaxonId>;
 

--- a/src/rmq/lca.rs
+++ b/src/rmq/lca.rs
@@ -54,6 +54,8 @@ impl LCACalculator {
     }
 }
 
+impl agg::MultiThreadSafeAggregator for LCACalculator{}
+
 impl agg::Aggregator for LCACalculator {
     fn aggregate(&self, taxons: &HashMap<TaxonId, f32>) -> agg::Result<TaxonId> {
         if taxons.is_empty() {

--- a/src/rmq/mix.rs
+++ b/src/rmq/mix.rs
@@ -50,6 +50,8 @@ fn factorize(weights: Weights, factor: f32) -> f32 {
     weights.lca * factor + weights.rtl * (1.0 - factor)
 }
 
+impl agg::MultiThreadSafeAggregator for MixCalculator {}
+
 impl agg::Aggregator for MixCalculator {
     fn aggregate(&self, taxons: &HashMap<TaxonId, f32>) -> agg::Result<TaxonId> {
         let mut weights: HashMap<TaxonId, Weights> = HashMap::with_capacity(taxons.len());
@@ -70,7 +72,7 @@ impl agg::Aggregator for MixCalculator {
             for (&right, &count) in taxons.iter() {
                 let lca = self.lca_aggregator.lca(left, right)?;
                 if lca == left || lca == right {
-                    let mut weight = weights.entry(left).or_insert_with(Weights::new);
+                    let weight = weights.entry(left).or_insert_with(Weights::new);
                     if lca == left {
                         weight.lca += count;
                     }

--- a/src/rmq/mix.rs
+++ b/src/rmq/mix.rs
@@ -72,7 +72,7 @@ impl agg::Aggregator for MixCalculator {
             for (&right, &count) in taxons.iter() {
                 let lca = self.lca_aggregator.lca(left, right)?;
                 if lca == left || lca == right {
-                    let weight = weights.entry(left).or_insert_with(Weights::new);
+                    let mut weight = weights.entry(left).or_insert_with(Weights::new);
                     if lca == left {
                         weight.lca += count;
                     }

--- a/src/rmq/rtl.rs
+++ b/src/rmq/rtl.rs
@@ -32,6 +32,8 @@ impl RTLCalculator {
     }
 }
 
+impl agg::MultiThreadSafeAggregator for RTLCalculator {}
+
 impl agg::Aggregator for RTLCalculator {
     /// Returns the taxon with the MRL for a given list of taxons.
     fn aggregate(&self, taxons: &HashMap<TaxonId, f32>) -> agg::Result<TaxonId> {

--- a/src/tree/lca.rs
+++ b/src/tree/lca.rs
@@ -28,6 +28,7 @@ impl LCACalculator {
         }
     }
 }
+impl agg::MultiThreadSafeAggregator for LCACalculator {}
 
 impl agg::Aggregator for LCACalculator {
     fn aggregate(&self, taxons: &HashMap<TaxonId, f32>) -> Result<TaxonId, agg::Error> {

--- a/src/tree/mix.rs
+++ b/src/tree/mix.rs
@@ -37,6 +37,8 @@ impl MixCalculator {
     }
 }
 
+impl agg::MultiThreadSafeAggregator for MixCalculator {}
+
 impl agg::Aggregator for MixCalculator {
     fn aggregate(&self, taxons: &HashMap<TaxonId, f32>) -> agg::Result<TaxonId> {
         if taxons.is_empty() {


### PR DESCRIPTION
This allows reusing an aggregator across multiple threads when multithreading